### PR TITLE
Better homing projectile

### DIFF
--- a/tower/projectiles/homingprojectile.cpp
+++ b/tower/projectiles/homingprojectile.cpp
@@ -29,29 +29,31 @@ namespace termd {
 
 		int row_dist = std::abs(delta.get_row());
 		int col_dist = std::abs(delta.get_col());
-		int diag_dist = std::abs(row_dist - col_dist);
+		int diag_dist = std::min(row_dist, col_dist);
 
-		if (row_dist < col_dist) { // Check if we have most rows or cols left
-			if (diag_dist <= col_dist) {// We should step in col
-				// Remove speed since we are going to step
-				speed_curr -= PROJ_STEPCOST;
-				if (delta.get_col() < 0) { // Check which dir we should step
-					pos.add_col(-1);
+		if (std::max(row_dist, col_dist) - diag_dist >= diag_dist) { // We want to move horizonally or vertically
+			if (row_dist < col_dist) { // Check if we have most rows or cols left
+				if (diag_dist <= col_dist) {// We should step in col
+					// Remove speed since we are going to step
+					speed_curr -= PROJ_STEPCOST;
+					if (delta.get_col() < 0) { // Check which dir we should step
+						pos.add_col(-1);
+						return true;
+					}
+					pos.add_col(1);
 					return true;
 				}
-				pos.add_col(1);
-				return true;
-			}
-		} else { // col_dist < row_dist
-			if (diag_dist <= row_dist) {
-				// Remove speed since we are going to step
-				speed_curr -= PROJ_STEPCOST;
-				if (delta.get_row() < 0) {// Check which dir we should step
-					pos.add_row(-1);
+			} else { // col_dist < row_dist
+				if (diag_dist <= row_dist) {
+					// Remove speed since we are going to step
+					speed_curr -= PROJ_STEPCOST;
+					if (delta.get_row() < 0) {// Check which dir we should step
+						pos.add_row(-1);
+						return true;
+					}
+					pos.add_row(1);
 					return true;
 				}
-				pos.add_row(1);
-				return true;
 			}
 		}
 		if (speed_curr < PROJ_STEPCOSTDIAGONAL) return false; // We cannot diagonally and are done

--- a/tower/projectiles/homingprojectile.cpp
+++ b/tower/projectiles/homingprojectile.cpp
@@ -23,72 +23,53 @@ namespace termd {
 
 	bool HomingProjectile::step() {
 		if (hit()) return false; //We already reached the target
+		if (speed_curr < PROJ_STEPCOST) return false; // We cannot move and are done
 
 		Coord delta = target.get_pos() - pos;
 
-		double angle = atan2(delta.get_row(), delta.get_col()) * -180 / PI;
-		angle = (angle > 0 ? angle : (360.0 + angle));
+		int row_dist = std::abs(delta.get_row());
+		int col_dist = std::abs(delta.get_col());
+		int diag_dist = std::abs(row_dist - col_dist);
 
-		if (angle < 45.0f/2.0f) { //go right
-			if (speed_curr >= PROJ_STEPCOST) {
+		if (row_dist < col_dist) { // Check if we have most rows or cols left
+			if (diag_dist <= col_dist) {// We should step in col
+				// Remove speed since we are going to step
 				speed_curr -= PROJ_STEPCOST;
+				if (delta.get_col() < 0) { // Check which dir we should step
+					pos.add_col(-1);
+					return true;
+				}
 				pos.add_col(1);
 				return true;
 			}
-		} else if (angle < 45.0f+45.0f/2.0f) { //go up right
-			if (speed_curr >= PROJ_STEPCOSTDIAGONAL) {
-				speed_curr -= PROJ_STEPCOSTDIAGONAL;
-				pos.add_col(1);
-				pos.add_row(-1);
-				return true;
-			}
-		} else if (angle < 2*45.0f+45.0f/2.0f) { //go up
-			if (speed_curr >= PROJ_STEPCOST) {
+		} else { // col_dist < row_dist
+			if (diag_dist <= row_dist) {
+				// Remove speed since we are going to step
 				speed_curr -= PROJ_STEPCOST;
-				pos.add_row(-1);
-				return true;
-			}
-		} else if (angle < 3*45.0f+45.0f/2.0f) { //go up left
-			if (speed_curr >= PROJ_STEPCOSTDIAGONAL) {
-				speed_curr -= PROJ_STEPCOSTDIAGONAL;
-				pos.add_col(-1);
-				pos.add_row(-1);
-				return true;
-			}
-		} else if (angle < 4*45.0f+45.0f/2.0f) { //go left
-			if (speed_curr >= PROJ_STEPCOST) {
-				speed_curr -= PROJ_STEPCOST;
-				pos.add_col(-1);
-				return true;
-			}
-		} else if (angle < 5*45.0f+45.0f/2.0f) { //go down left
-			if (speed_curr >= PROJ_STEPCOSTDIAGONAL) {
-				speed_curr -= PROJ_STEPCOSTDIAGONAL;
-				pos.add_col(-1);
+				if (delta.get_row() < 0) {// Check which dir we should step
+					pos.add_row(-1);
+					return true;
+				}
 				pos.add_row(1);
-				return true;
-			}
-		} else if (angle < 6*45.0f+45.0f/2.0f) { //go down
-			if (speed_curr >= PROJ_STEPCOST) {
-				speed_curr -= PROJ_STEPCOST;
-				pos.add_row(1);
-				return true;
-			}
-		} else if (angle < 7*45.0f+45.0f/2.0f) { //go down right
-			if (speed_curr >= PROJ_STEPCOSTDIAGONAL) {
-				speed_curr -= PROJ_STEPCOSTDIAGONAL;
-				pos.add_col(1);
-				pos.add_row(1);
-				return true;
-			}
-		} else { //go right
-			if (speed_curr >= PROJ_STEPCOST) {
-				speed_curr -= PROJ_STEPCOST;
-				pos.add_col(1);
 				return true;
 			}
 		}
-		return false;
+		if (speed_curr < PROJ_STEPCOSTDIAGONAL) return false; // We cannot diagonally and are done
+		//Remove speed since we are goind to step
+		speed_curr -= PROJ_STEPCOSTDIAGONAL;
+
+		if (delta.get_row() < 0) {
+			pos.add_row(-1);
+		} else { //delta.get_row >= 0
+			pos.add_row(1);
+		}
+		if (delta.get_col() < 0) {
+			pos.add_col(-1);
+		} else {
+			pos.add_col(1);
+		}
+
+		return true;
 	}
 
 	bool HomingProjectile::update() {

--- a/tower/projectiles/homingprojectile.hpp
+++ b/tower/projectiles/homingprojectile.hpp
@@ -1,6 +1,7 @@
 #ifndef termd_homing_projectile
 #define termd_homing_projectile
 
+#include <cstdlib>
 #include "projectilebase.hpp"
 #include "projectile.hpp"
 
@@ -13,7 +14,7 @@ namespace termd {
 			int speed_curr;
 
 			bool hit() const;
-			bool step();
+			bool step(); // returns true iff projectile steped
 			void move();
 
 		protected:


### PR DESCRIPTION
What it says in commit: https://github.com/langest/terminal_defense/commit/e6c169eaee406c5b439e79cbc9979f576f76c554

Now the homing prjectile moves in a better path than before.
It can still be hard to see if the distance to the target is great.
See the commit in the link or below for ascii explanation.

Markdown does not like whitespace.